### PR TITLE
Set up url routes for client requests to '/login' and '/register'

### DIFF
--- a/survivorapi/views/__init__.py
+++ b/survivorapi/views/__init__.py
@@ -1,0 +1,1 @@
+from .auth import login_user, register_user

--- a/survivorapi/views/auth.py
+++ b/survivorapi/views/auth.py
@@ -1,0 +1,80 @@
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+from rest_framework.authtoken.models import Token
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def login_user(request):
+    '''Handles the authentication of a gamer
+
+    Method arguments:
+      request -- The full HTTP request object
+    '''
+    email = request.data['email']
+    password = request.data['password']
+
+    # Use the built-in authenticate method to verify
+    # authenticate returns the user object or None if no user is found
+    authenticated_user = authenticate(username=email, password=password)
+
+    # If authentication was successful, respond with their token
+    if authenticated_user is not None:
+        token = Token.objects.get(user=authenticated_user)
+
+        data = {
+            'valid': True,
+            'token': token.key
+        }
+        return Response(data)
+    else:
+        # Bad login details were provided. So we can't log the user in.
+        data = { 'valid': False }
+        return Response(data)
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def register_user(request):
+    '''Handles the creation of a new gamer for authentication
+
+    Method arguments:
+      request -- The full HTTP request object
+    '''
+    email = request.data.get('email', None)
+    first_name = request.data.get('first_name', None)
+    last_name = request.data.get('last_name', None)
+    password = request.data.get('password', None)
+
+    if email is not None\
+        and first_name is not None \
+        and last_name is not None \
+        and password is not None:
+
+        try:
+            # Create a new user by invoking the `create_user` helper method
+            # on Django's built-in User model
+            new_user = User.objects.create_user(
+                username=request.data['email'],
+                email=request.data['email'],
+                password=request.data['password'],
+                first_name=request.data['first_name'],
+                last_name=request.data['last_name']
+            )
+        except IntegrityError:
+            return Response(
+                {'message': 'An account with that username already exists'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Use the REST Framework's token generator on the new user account
+        token = Token.objects.create(user=new_user)
+        # Return the token to the client
+        data = { 'token': token.key }
+        return Response(data)
+
+    return Response({'message': 'You must provide email, password, first_name, and last_name'}, status=status.HTTP_400_BAD_REQUEST)

--- a/survivorproject/urls.py
+++ b/survivorproject/urls.py
@@ -1,10 +1,14 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
+from survivorapi.views import login_user, register_user
 
 router = routers.DefaultRouter(trailing_slash=False)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('register', register_user),
+    path('login', login_user),
+    path('admin/', admin.site.urls),
 ]
 


### PR DESCRIPTION
- Defined 'login_user()' and 'register_user()' functions in views/auth.py
- Imported both functions into the views package
- Set up routes for client requests to '/register' and '/login' in urls.py
- Successfully tested registering a new user and logging in that new user via Postman, with an auth token returned in the response & the new User added to the database:

Postman POST request to '/register'
Request body:
{
   "email": "jana@survivor.com",
   "password": "*******",
   "first_name": "Jana",
   "last_name": "Ismail"
}

Response body:
{
    "token": "{generated token}"
}

Postman POST request to '/login'
Request body:
{
   "email": "jana@survivor.com",
   "password": "*******",
}

Response body:
{
    "valid": true,
    "token": "{generated token}"
}