### PR TITLE
Created SurvivorTribes viewset with custom POST and querset ops

### DIFF
--- a/survivorapi/models/survivor.py
+++ b/survivorapi/models/survivor.py
@@ -6,3 +6,8 @@ class Survivor(models.Model):
     last_name = models.CharField(max_length=100)
     age = models.IntegerField()
     img_url = models.URLField(null=True, blank=True)
+    tribes = models.ManyToManyField(
+        "Survivor",
+        through="SurvivorTribe",
+        related_name="survivors"
+    )

--- a/survivorapi/views/__init__.py
+++ b/survivorapi/views/__init__.py
@@ -3,3 +3,4 @@ from .season_logs import SeasonLogs
 from .seasons import Seasons
 from .tribes import Tribes
 from .survivors import Survivors
+from .survivor_tribes import SurvivorTribes

--- a/survivorapi/views/survivor_tribes.py
+++ b/survivorapi/views/survivor_tribes.py
@@ -1,0 +1,103 @@
+from rest_framework import viewsets, permissions
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from survivorapi.models import SurvivorTribe, Survivor, Tribe, Season
+
+class SeasonSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Season
+        fields = [
+            'id', 'season_number', 'name', 'location',
+            'start_date', 'end_date', 'is_current'
+        ]
+
+class SurvivorSerializer(serializers.ModelSerializer):
+    season = SeasonSerializer(read_only=True) # For GET requests
+    season_id = serializers.IntegerField(write_only=True) # For POST/PUT requests
+    
+    class Meta:
+        model = Survivor
+        fields = ['id', 'first_name', 'last_name', 'age', 'season', 'season_id']
+
+class TribeSerializer(serializers.ModelSerializer):
+    season_id = serializers.IntegerField() # For POST/PUT requests
+
+    class Meta:
+        model = Tribe
+        fields = ['id', 'season_id', 'name', 'color', 'is_merge_tribe']
+
+class SurvivorTribeSerializer(serializers.ModelSerializer):
+    # Add nested serializers for detailed GET responses
+    survivor = SurvivorSerializer(read_only=True)
+    tribe = TribeSerializer(read_only=True)
+
+    # Add write-only fields for POST/PUT requests
+    survivor_id = serializers.ImageField(write_only=True)
+    tribe_id = serializers.IntegerField(write_only=True)
+
+    class Meta:
+        model = SurvivorTribe
+        fields = ['id', 'survivor', 'tribe', 'survivor_id', 'tribe_id']
+
+class SurvivorTribes(viewsets.ModelViewSet):
+    """
+    A ViewSet for viewing and managing survivor-tribe relationships
+    """
+
+    queryset = SurvivorTribe.objects.all()
+    serializer_class = SurvivorTribeSerializer
+
+    def get_permissions(self):
+        if self.action in ['list', 'retrieve']:
+            permission_classes = [permissions.IsAuthenticated]
+        else:
+            permission_classes = [permissions.IsAdminUser]
+        return [permission() for permission in permission_classes]
+
+    def get_queryset(self):
+        # Might refactor to take this out later and utilize many to many field on Models instead
+        # But this might be relevant for filtering on the client side
+        """
+        Optionally filter survivor-tribe relationships by survivor_id,
+        tribe_id, or season_id query params
+        """
+        queryset = SurvivorTribe.objects.all()
+
+        survivor_id = self.request.query_params.get('survivor', None)
+        tribe_id = self.request.query_params.get('tribe', None)
+        season_id = self.request.query_params.get('season', None)
+
+        if survivor_id:
+            queryset = queryset.filter(survivor_id=survivor_id)
+        if tribe_id:
+            queryset = queryset.filter(tribe_id=tribe_id)
+        if season_id:
+            queryset = queryset.filter(season_id=season_id)
+        
+        return queryset
+    
+    def create(self, request, *args, **kwargs):
+        """Method for admin user to create a survivor-tribe relationship"""
+        try:
+            survivor = Survivor.objects.get(pk=request.data["survivor_id"])
+            tribe = Tribe.objects.get(pk=request.data["tribe_id"])
+
+            if survivor.season_id != tribe.season.id:
+                return Response(
+                    {"reason": "Survivor and tribe must be from the same season"},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            survivor_tribe = SurvivorTribe.objects.create(
+                survivor=survivor,
+                tribe=tribe
+            )
+
+            serializer = SurvivorTribeSerializer(survivor_tribe)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except Exception as ex:
+            return Response(
+                {"reason": ex.args[0]}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/survivorproject/urls.py
+++ b/survivorproject/urls.py
@@ -1,13 +1,14 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from survivorapi.views import login_user, register_user, SeasonLogs, Seasons, Tribes, Survivors
+from survivorapi.views import login_user, register_user, SeasonLogs, Seasons, Tribes, Survivors, SurvivorTribes
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"season-logs", SeasonLogs, "season-log")
 router.register(r"seasons", Seasons, "season")
 router.register(r"tribes", Tribes, "tribe")
 router.register(r"survivors", Survivors, "survivor")
+router.register(r"survivor-tribes", SurvivorTribes, "survivor-tribes")
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
## Changes

- Created SurvivorTribes model ViewSet
- Registered url route to `/survivor-tribes`
- Built-in model viewset functions for GET & DELETE operations
- Custom functionality for create() method for POST operations
- All authorized/logged in users have read-only permissions for GET requests to `/survivor-tribes`
- Only admin users have POST & DELETE permissions
- Added get_queryset() method for query_params to `/survivor-tribes` that include `season_id`,  `tribe_id`, and `survivor_id` => Also added a many-to-many field on the Survivor Model, will evaluate which route to take (or both) once I start building out the client side

## Postman testing
GET `/survivor-tribes`

**Request** 
 Send with any Authorization: Token {token} property in body of header

**Response**
Returns a list of all survivor objects with expanded season object
```json
[
    {
        "id": 1,
        "survivor": {
            "id": 1,
            "first_name": "Gabe",
            "last_name": "Ortis",
            "age": 26,
            "season": {
                "id": 1,
                "season_number": 47,
                "name": "Survivor 47",
                "location": "Fiji",
                "start_date": "2024-09-18",
                "end_date": "2024-12-11",
                "is_current": true
            }
        },
        "tribe": {
            "id": 2,
            "season_id": 1,
            "name": "Tuku",
            "color": "blue",
            "is_merge_tribe": false
        }
    },
    {
        "id": 2,
        "survivor": {
            "id": 5,
            "first_name": "Terran 'TK'",
            "last_name": "Foster",
            "age": 31,
            "season": {
                "id": 1,
                "season_number": 47,
                "name": "Survivor 47",
                "location": "Fiji",
                "start_date": "2024-09-18",
                "end_date": "2024-12-11",
                "is_current": true
            }
        },
        "tribe": {
            "id": 2,
            "season_id": 1,
            "name": "Tuku",
            "color": "blue",
            "is_merge_tribe": false
        }
    }, {...}
]
```
GET `/survivors/{pk}`

**Request**
Send with any auth token in body of header

**Response**
Returns a single survivor resource with expanded season
```json
{
    "id": 5,
    "survivor": {
        "id": 13,
        "first_name": "Caroline",
        "last_name": "Vidmar",
        "age": 27,
        "season": {
            "id": 1,
            "season_number": 47,
            "name": "Survivor 47",
            "location": "Fiji",
            "start_date": "2024-09-18",
            "end_date": "2024-12-11",
            "is_current": true
        }
    },
    "tribe": {
        "id": 2,
        "season_id": 1,
        "name": "Tuku",
        "color": "blue",
        "is_merge_tribe": false
    }
}
```

POST `/survivor-tribes`
**Request**
Send with admin user's auth token in body of header
Request body with new resource data:
```json
{
    "survivor_id": 2,
    "tribe_id": 67
}
```

**Response**
Returns a 201 Created status with new resource id + data in response body
```json
{
    "id": 21,
    "survivor": {
        "id": 2,
        "first_name": "Teeny",
        "last_name": "Chirichillo",
        "age": 24,
        "season": {
            "id": 1,
            "season_number": 47,
            "name": "Survivor 47",
            "location": "Fiji",
            "start_date": "2024-09-18",
            "end_date": "2024-12-11",
            "is_current": true
        }
    },
    "tribe": {
        "id": 67,
        "season_id": 1,
        "name": "Unknown Merge Tribe",
        "color": "black",
        "is_merge_tribe": true
    }
}
```

DELETE `/survivors/{pk}`
**Request**
Send with admin user's auth token in body of header

**Response**
204 No Content